### PR TITLE
🛠 Add Github Action

### DIFF
--- a/.github/actions/setup-terraform-backend-git/Dockerfile
+++ b/.github/actions/setup-terraform-backend-git/Dockerfile
@@ -1,6 +1,6 @@
 # The action uses an own Dockerfile on purpose because the root Dockerfile takes way too long to build for an action
 
-FROM alpine:latest
+FROM alpine:3.10
 
 RUN	apk add --no-cache \
   bash \

--- a/.github/actions/setup-terraform-backend-git/Dockerfile
+++ b/.github/actions/setup-terraform-backend-git/Dockerfile
@@ -1,0 +1,15 @@
+# The action uses an own Dockerfile on purpose because the root Dockerfile takes way too long to build for an action
+
+FROM alpine:latest
+
+RUN	apk add --no-cache \
+  bash \
+  ca-certificates \
+  curl \
+  wget \
+  tar \
+  jq
+
+COPY get_terraform-backend-git.sh /get_terraform-backend-git.sh
+
+ENTRYPOINT ["/get_terraform-backend-git.sh"]

--- a/.github/actions/setup-terraform-backend-git/action.yml
+++ b/.github/actions/setup-terraform-backend-git/action.yml
@@ -1,0 +1,22 @@
+name: 'Install terraform-backend-git'
+description: 'Download a specific terraform-backend-git version'
+
+inputs:
+  version:
+    description: 'version of terraform-backend-git'
+    required: true
+    default: 'latest'
+
+runs:
+  using: 'docker'
+  image: './Dockerfile'
+  args:
+    - ${{ inputs.version }}
+
+outputs:
+  version:
+    description: 'Version of terraform-backend-git installed'
+
+branding:
+  icon: 'download-cloud'
+  color: 'gray-dark'

--- a/.github/actions/setup-terraform-backend-git/get_terraform-backend-git.sh
+++ b/.github/actions/setup-terraform-backend-git/get_terraform-backend-git.sh
@@ -14,5 +14,6 @@ fi
 mkdir terraform-backend-git
 TARGET_FILE="terraform-backend-git"
 curl -LJ -o terraform-backend-git/$TARGET_FILE 'https://github.com/plumber-cd/terraform-backend-git/releases/download/'"$INPUT_VERSION"'/terraform-backend-git-darwin-386'
+chmod +x terraform-backend-git/$TARGET_FILE
 echo "terraform-backend-git" >> $GITHUB_PATH
 echo "::set-output name=version::$INPUT_VERSION"

--- a/.github/actions/setup-terraform-backend-git/get_terraform-backend-git.sh
+++ b/.github/actions/setup-terraform-backend-git/get_terraform-backend-git.sh
@@ -13,7 +13,7 @@ fi
 
 mkdir terraform-backend-git
 TARGET_FILE="terraform-backend-git"
-curl -LJ -o terraform-backend-git/$TARGET_FILE 'https://github.com/plumber-cd/terraform-backend-git/releases/download/'"$INPUT_VERSION"'/terraform-backend-git-darwin-386'
+curl -LJ -o terraform-backend-git/$TARGET_FILE 'https://github.com/plumber-cd/terraform-backend-git/releases/download/'"$INPUT_VERSION"'/terraform-backend-git-darwin-amd64'
 chmod +x terraform-backend-git/$TARGET_FILE
 echo "terraform-backend-git" >> $GITHUB_PATH
 echo "::set-output name=version::$INPUT_VERSION"

--- a/.github/actions/setup-terraform-backend-git/get_terraform-backend-git.sh
+++ b/.github/actions/setup-terraform-backend-git/get_terraform-backend-git.sh
@@ -13,7 +13,7 @@ fi
 
 mkdir terraform-backend-git
 TARGET_FILE="terraform-backend-git"
-curl -LJ -o terraform-backend-git/$TARGET_FILE 'https://github.com/plumber-cd/terraform-backend-git/releases/download/'"$INPUT_VERSION"'/terraform-backend-git-darwin-amd64'
+curl -LJ -o terraform-backend-git/$TARGET_FILE 'https://github.com/plumber-cd/terraform-backend-git/releases/download/'"$INPUT_VERSION"'/terraform-backend-git-linux-386'
 chmod +x terraform-backend-git/$TARGET_FILE
 echo "terraform-backend-git" >> $GITHUB_PATH
 echo "::set-output name=version::$INPUT_VERSION"

--- a/.github/actions/setup-terraform-backend-git/get_terraform-backend-git.sh
+++ b/.github/actions/setup-terraform-backend-git/get_terraform-backend-git.sh
@@ -12,7 +12,7 @@ else
 fi
 
 mkdir terraform-backend-git
-TARGET_FILE="terraform-backend-git.tar.gz"
+TARGET_FILE="terraform-backend-git"
 curl -LJ -o terraform-backend-git/$TARGET_FILE 'https://github.com/plumber-cd/terraform-backend-git/releases/download/'"$INPUT_VERSION"'/terraform-backend-git-darwin-386'
 echo "terraform-backend-git" >> $GITHUB_PATH
 echo "::set-output name=version::$INPUT_VERSION"

--- a/.github/actions/setup-terraform-backend-git/get_terraform-backend-git.sh
+++ b/.github/actions/setup-terraform-backend-git/get_terraform-backend-git.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+if [[ -z "$INPUT_VERSION" ]]; then
+  echo "Missing terraform-backend-git version information"
+  exit 1
+fi
+terraform-backend-git version | grep "$INPUT_VERSION" &> /dev/null
+if [ $? == 0 ]; then
+   echo "terraform-backend-git $INPUT_VERSION is already installed! Exiting gracefully."
+   exit 0
+else
+  echo "Installing terraform-backend-git to path."
+fi
+
+mkdir terraform-backend-git
+TARGET_FILE="terraform-backend-git.tar.gz"
+curl -LJ -o terraform-backend-git/$TARGET_FILE 'https://github.com/plumber-cd/terraform-backend-git/releases/download/'"$INPUT_VERSION"'/terraform-backend-git-darwin-386'
+echo "terraform-backend-git" >> $GITHUB_PATH
+echo "::set-output name=version::$INPUT_VERSION"

--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -1,0 +1,26 @@
+name: Test terraform-backend-git action
+on:
+  push:
+    branches: [ master ]
+jobs:
+  build-int:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup terraform-backend-git
+        uses: ./.github/actions/setup-terraform-backend-git
+        with:
+          version: v0.0.14
+      - name: Use command
+        run: terraform-backend-git version
+# @dee-kryvenko this will only work once merged to your repo
+#  build-ext:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Setup terraform-backend-git
+#        uses: plumber-cd/terraform-backend-git@master
+#        with:
+#          version: v0.0.14
+#      - name: Use command
+#        run: terraform-backend-git version


### PR DESCRIPTION
Downloads executable and links it to the runners' path
Also clarifies some documentation

Notes:
- It might be a good idea to tarball the executable (then the setup script must be changed of course)
- Somehow, the HCL `--config` does not make sense yet. To whom do I pass that argument