### PR TITLE
Using native validation if SSH-Agent is available.

### DIFF
--- a/storages/git/git.go
+++ b/storages/git/git.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bytes"
 	"errors"
+	sshagent "github.com/xanzy/ssh-agent"
 	"io"
 	"io/ioutil"
 	"os"
@@ -45,10 +46,12 @@ func authBasicHTTP() (*http.BasicAuth, error) {
 	}, nil
 }
 
-// authSSHAgent discovers environment for SSH_AUTH_SOCK and builds NewSSHAgentAuth
+// authSSHAgent discovers environment for SSH_AUTH_SOCK (or other platform dependent logic)
+// and builds NewSSHAgentAuth.
+//
 // If returned null - no agent was set up
 func authSSHAgent(params *RequestMetadataParams) (*sshGit.PublicKeysCallback, error) {
-	if _, ok := os.LookupEnv("SSH_AUTH_SOCK"); !ok {
+	if !sshagent.Available() {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Instead of using _just_ checking if `SSH_AUTH_SOCK` we use `sshagent.Available()` which also checks in more platform dependent ways if an SSH-Agent is available and working. Especially on Windows this variable is usually not present but a Pageant or Windows OpenSSH-Agent might run already. Currently you can only work with them by setting some junk into this environment variable before running the service.

#### Scope of change
Sorry for the whole change of the file. It seems that in the repository there was initially the files stored with `crlf` (as reported by `git ls-files --eol`). I tried several ways to clean this up, but was not successful. Although the change itself is just focused on:

Old:
```go
// authSSHAgent discovers environment for SSH_AUTH_SOCK and builds NewSSHAgentAuth
// If returned null - no agent was set up
func authSSHAgent(params *RequestMetadataParams) (*sshGit.PublicKeysCallback, error) {
	if _, ok := os.LookupEnv("SSH_AUTH_SOCK"); !ok {
		return nil, nil
	}
```

New:
```go
import (
[..]
	sshagent "github.com/xanzy/ssh-agent"
[..]
)
[..]
// authSSHAgent discovers environment for SSH_AUTH_SOCK (or other platform dependent logic)
// and builds NewSSHAgentAuth.
//
// If returned null - no agent was set up
func authSSHAgent(params *RequestMetadataParams) (*sshGit.PublicKeysCallback, error) {
	if !sshagent.Available() {
		return nil, nil
	}
```