### PR TITLE
Publish ARM64 image (for Apple Silicon)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,10 @@ jobs:
         run: echo "RELEASE_STRING=v${RELEASE_VERSION}" >> $GITHUB_ENV
       - name: Checkout Code
         uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
@@ -75,6 +79,7 @@ jobs:
           build-args: |
             RELEASE_STRING=${{ env.RELEASE_STRING }}
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
   release:


### PR DESCRIPTION
It should be possible to use this image on Apple Silicon without enabling Rosetta in the Docker Desktop options.

Closes #34